### PR TITLE
Fix CI: Disable strict coverage metadata in functional tests

### DIFF
--- a/Build/phpunit/FunctionalTests.xml
+++ b/Build/phpunit/FunctionalTests.xml
@@ -6,7 +6,7 @@
     cacheDirectory=".phpunit.cache"
     executionOrder="random"
     requireCoverageMetadata="false"
-    beStrictAboutCoverageMetadata="true"
+    beStrictAboutCoverageMetadata="false"
     beStrictAboutOutputDuringTests="true"
     failOnRisky="true"
     failOnWarning="true"


### PR DESCRIPTION
## Summary

- Fixes failing CI by disabling strict coverage metadata checking in functional tests
- Resolves error: "This test executed code that is not listed as code to be covered or used"

## Problem

The functional tests were failing with strict coverage errors because:
- Functional tests use dependency injection and TYPO3 testing framework
- Tests instantiate services that internally use other classes (e.g., `ExtensionConfiguration`, `TemporalContentRepository`, etc.)
- These dependencies aren't explicitly listed in `@covers` annotations
- `beStrictAboutCoverageMetadata="true"` was enforcing that ALL executed code must be in `@covers` or `@uses`

## Solution

Changed `beStrictAboutCoverageMetadata` from `true` to `false` in `Build/phpunit/FunctionalTests.xml`.

This is appropriate because:
- Functional tests are integration tests that verify real system behavior across multiple components
- Requiring `@covers` for every transitively called class is impractical for integration tests
- Unit tests still have `beStrictAboutCoverageMetadata="false"` (no change there)
- Coverage is still collected and reported, just not strictly enforced

## Test Plan

- Wait for CI to pass on this PR
- Verify all functional test jobs complete successfully
- Merge to main