### PR TITLE
ci: migrate docs to shared workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -2,29 +2,22 @@ name: Documentation
 
 on:
   push:
-    branches: [ main ]
+    branches: [main]
     paths:
       - 'Documentation/**'
       - '.github/workflows/docs.yml'
-  repository_dispatch:
-    types: [ documentation ]
+  pull_request:
+    branches: [main]
+    paths:
+      - 'Documentation/**'
+      - '.github/workflows/docs.yml'
+  merge_group:
+  workflow_dispatch:
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
-  trigger-docs-build:
-    name: Trigger docs.typo3.org rebuild
-    runs-on: ubuntu-latest
-    steps:
-      - name: Harden Runner
-        uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2.16.0
-        with:
-          egress-policy: audit
-
-      - name: Notify docs.typo3.org
-        run: |
-          curl -X POST \
-            -H "Content-Type: application/json" \
-            -d '{"branch": "main"}' \
-            "https://docs.typo3.org/service/webhooks/github/${{ github.repository }}"
+  docs:
+    uses: netresearch/typo3-ci-workflows/.github/workflows/docs.yml@main
+    permissions:
+      contents: read


### PR DESCRIPTION
## Summary

- Replace local `docs.yml` with a thin caller to `netresearch/typo3-ci-workflows/.github/workflows/docs.yml@main`.
- The old workflow only fired a webhook to `docs.typo3.org` on push to main. It did not render documentation locally or validate it on PRs.
- The new shared workflow renders documentation locally using `typo3-documentation/render-guides`, checks for warnings, and uploads artifacts on PRs — a net improvement for PR validation.
- The docs.typo3.org webhook notification should already be configured in GitHub repository settings (as is the case for other TYPO3 extensions that render docs locally).

## Test plan

- [ ] Verify docs workflow triggers on Documentation/** changes
- [ ] Confirm docs.typo3.org webhook is configured in repo settings (independent of this workflow)