### PR TITLE
ci: adopt canonical typo3-extension template

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,10 +1,49 @@
+# Managed by netresearch/.github/templates/typo3-extension/
+#
+# Declares only the ecosystems every typo3-extension consumer is guaranteed to
+# have: composer (the extension's composer.json) and github-actions.
+#
+# npm is OPT-IN: an extension that actually ships a package.json (frontend
+# assets) adds the block below to its own dependabot.yml and lists
+# `.github/dependabot.yml` under `intentional-drift:` in .github/template.yaml
+# so the template sync stops managing the file. Declaring an ecosystem without
+# its manifest makes the Dependabot run fail with `dependency_file_not_found`.
+#
+# Opt-in npm:
+#   - package-ecosystem: npm
+#     directory: /
+#     schedule:
+#       interval: weekly
+#       day: monday
+#     open-pull-requests-limit: 5
+#     groups:
+#       npm:
+#         patterns: ['*']
+#     cooldown:
+#       default-days: 7
 version: 2
 updates:
+  - package-ecosystem: composer
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 10
+    versioning-strategy: increase-if-necessary
+    groups:
+      composer:
+        patterns: ['*']
+    cooldown:
+      default-days: 7
+
   - package-ecosystem: github-actions
     directory: /
     schedule:
       interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
     groups:
       github-actions:
-        patterns:
-          - "*"
+        patterns: ['*']
+    cooldown:
+      default-days: 7

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,29 +1,17 @@
+# Label configuration for PR Labeler
+# https://github.com/actions/labeler
 documentation:
   - changed-files:
-      - any-glob-to-any-file:
-          - 'Documentation/**'
-          - '*.md'
-
-configuration:
-  - changed-files:
-      - any-glob-to-any-file:
-          - 'Configuration/**'
-          - 'ext_emconf.php'
-          - 'composer.json'
-
+      - any-glob-to-any-file: ['Documentation/**/*', '**/*.md']
 tests:
   - changed-files:
-      - any-glob-to-any-file:
-          - 'Tests/**'
-          - 'phpunit*.xml'
-
+      - any-glob-to-any-file: ['Tests/**/*', 'Build/phpunit/**/*']
 ci:
   - changed-files:
-      - any-glob-to-any-file:
-          - '.github/**'
-
+      - any-glob-to-any-file: ['.github/**/*', 'Build/**/*']
 dependencies:
   - changed-files:
-      - any-glob-to-any-file:
-          - 'composer.json'
-          - 'composer.lock'
+      - any-glob-to-any-file: ['composer.json', 'composer.lock', 'package.json', 'package-lock.json', 'yarn.lock']
+configuration:
+  - changed-files:
+      - any-glob-to-any-file: ['Configuration/**/*', 'ext_*.php', 'composer.json']

--- a/.github/template.yaml
+++ b/.github/template.yaml
@@ -1,0 +1,15 @@
+# Managed by netresearch/.github/templates/typo3-extension/
+# Drift from the template is blocking CI in this repo (check-template-drift.yml).
+# Record explicit exceptions under intentional-drift[] to unblock.
+#
+# Split-file model: the security/quality jobs (elevated permissions) live in the
+# byte-identical, drift-enforced checks.yml. The two files below are
+# per-extension and are NOT byte-governed:
+#   - .github/workflows/ci.yml      — the test matrix `with:` block (php/typo3
+#     versions, matrix-exclude, functional-tests, db, remove-dev-deps, coverage)
+#   - .github/workflows/release.yml — archive-prefix / package-name / extension-key
+# Customize those two in-repo; everything else stays in sync with the template.
+template: typo3-extension
+intentional-drift:
+  - .github/workflows/ci.yml
+  - .github/workflows/release.yml

--- a/.github/workflows/auto-merge-deps.yml
+++ b/.github/workflows/auto-merge-deps.yml
@@ -1,7 +1,10 @@
 name: Auto-merge dependency PRs
 
 on:
-  pull_request:
+  # auto-merge only calls `gh pr merge` via the reusable with the base-repo
+  # token; it never checks out or runs PR head code, so pull_request_target
+  # (required for a write token on Dependabot/Renovate fork PRs) is safe here.
+  pull_request_target: # zizmor: ignore[dangerous-triggers]
 
 permissions: {}
 

--- a/.github/workflows/check-template-drift.yml
+++ b/.github/workflows/check-template-drift.yml
@@ -1,0 +1,18 @@
+name: Template Drift
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+  merge_group:
+
+permissions: {}
+
+jobs:
+  drift:
+    uses: netresearch/.github/.github/workflows/check-template-drift.yml@main
+    with:
+      template: typo3-extension
+    permissions:
+      contents: read

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -1,0 +1,70 @@
+name: Checks
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  merge_group:
+  schedule:
+    - cron: '0 6 * * 1'
+
+permissions: {}
+
+# Security + quality jobs with their explicit per-call-site permissions. This
+# file is byte-identical and drift-enforced across every typo3-extension — the
+# extension-specific test matrix lives in ci.yml (intentional-drift). Every
+# `uses:` job grants exactly the reusable's caller contract; no reliance on
+# default_workflow_permissions.
+jobs:
+  security:
+    uses: netresearch/typo3-ci-workflows/.github/workflows/security.yml@main
+    permissions:
+      contents: read
+      security-events: write
+
+  fuzz:
+    uses: netresearch/typo3-ci-workflows/.github/workflows/fuzz.yml@main
+    permissions:
+      contents: read
+
+  license-check:
+    uses: netresearch/typo3-ci-workflows/.github/workflows/license-check.yml@main
+    permissions:
+      contents: read
+
+  codeql:
+    uses: netresearch/.github/.github/workflows/codeql.yml@main
+    permissions:
+      contents: read
+      security-events: write
+      actions: read
+
+  scorecard:
+    if: github.event_name == 'schedule' || (github.event_name == 'push' && github.ref_name == github.event.repository.default_branch)
+    uses: netresearch/.github/.github/workflows/scorecard.yml@main
+    permissions:
+      contents: read
+      security-events: write
+      id-token: write
+      actions: read
+
+  dependency-review:
+    if: github.event_name == 'pull_request'
+    uses: netresearch/.github/.github/workflows/dependency-review.yml@main
+    permissions:
+      contents: read
+      pull-requests: write
+
+  pr-quality:
+    if: github.event_name == 'pull_request'
+    uses: netresearch/.github/.github/workflows/pr-quality.yml@main
+    permissions:
+      contents: read
+      pull-requests: write
+
+  labeler:
+    if: github.event_name == 'pull_request'
+    uses: netresearch/.github/.github/workflows/labeler.yml@main
+    permissions:
+      contents: read
+      pull-requests: write

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,75 +2,25 @@ name: CI
 
 on:
   push:
+    branches: [main]
   pull_request:
   merge_group:
   schedule:
     - cron: '0 6 * * 1'
 
-permissions: {}
+permissions:
+  contents: read
 
+# Per-extension test matrix (intentional-drift). Security/quality jobs are in checks.yml.
 jobs:
   ci:
     uses: netresearch/typo3-ci-workflows/.github/workflows/ci.yml@main
     permissions:
       contents: read
     with:
-        php-versions: '["8.1","8.2","8.3","8.4","8.5"]'
-        typo3-versions: '["^12.4","^13.0","^14.0"]'
-        matrix-exclude: '[{"php":"8.1","typo3":"^13.0"},{"php":"8.1","typo3":"^14.0"},{"php":"8.2","typo3":"^14.0"},{"php":"8.5","typo3":"^12.4"}]'
-        run-functional-tests: true
+      php-versions: '["8.1","8.2","8.3","8.4","8.5"]'
+      typo3-versions: '["^12.4","^13.0","^14.0"]'
+      matrix-exclude: '[{"php":"8.1","typo3":"^13.0"},{"php":"8.1","typo3":"^14.0"},{"php":"8.2","typo3":"^14.0"},{"php":"8.5","typo3":"^12.4"}]'
+      run-functional-tests: true
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-
-  security:
-    uses: netresearch/typo3-ci-workflows/.github/workflows/security.yml@main
-    permissions:
-      contents: read
-      security-events: write
-
-  fuzz:
-    uses: netresearch/typo3-ci-workflows/.github/workflows/fuzz.yml@main
-    permissions:
-      contents: read
-
-  license-check:
-    uses: netresearch/typo3-ci-workflows/.github/workflows/license-check.yml@main
-    permissions:
-      contents: read
-
-  codeql:
-    uses: netresearch/.github/.github/workflows/codeql.yml@main
-    permissions:
-      contents: read
-      security-events: write
-      actions: read
-
-  scorecard:
-    if: github.event_name == 'schedule' || (github.event_name == 'push' && github.ref_name == github.event.repository.default_branch)
-    uses: netresearch/.github/.github/workflows/scorecard.yml@main
-    permissions:
-      contents: read
-      security-events: write
-      id-token: write
-      actions: read
-
-  dependency-review:
-    if: github.event_name == 'pull_request'
-    uses: netresearch/.github/.github/workflows/dependency-review.yml@main
-    permissions:
-      contents: read
-      pull-requests: write
-
-  pr-quality:
-    if: github.event_name == 'pull_request'
-    uses: netresearch/.github/.github/workflows/pr-quality.yml@main
-    permissions:
-      contents: read
-      pull-requests: write
-
-  labeler:
-    if: github.event_name == 'pull_request'
-    uses: netresearch/.github/.github/workflows/labeler.yml@main
-    permissions:
-      contents: read
-      pull-requests: write

--- a/.github/workflows/community.yml
+++ b/.github/workflows/community.yml
@@ -5,7 +5,10 @@ on:
     - cron: '0 0 * * *'
   issues:
     types: [opened]
-  pull_request_target:
+  # greetings only posts a first-time contributor comment via the reusable; it
+  # never checks out or runs PR head code. pull_request_target is required to
+  # comment on fork PRs.
+  pull_request_target: # zizmor: ignore[dangerous-triggers]
     types: [opened]
   workflow_dispatch:
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,8 +15,8 @@ jobs:
       id-token: write
       attestations: write
     with:
-      archive-prefix: nr-temporal-cache
-      package-name: netresearch/nr-temporal-cache
-      extension-key: nr_temporal_cache
+      archive-prefix: 'nr-temporal-cache'
+      package-name: 'netresearch/nr-temporal-cache'
+      extension-key: 'nr_temporal_cache'
     secrets:
       TYPO3_TER_ACCESS_TOKEN: ${{ secrets.TYPO3_TER_ACCESS_TOKEN }}


### PR DESCRIPTION
Migrate CI to the canonical `typo3-extension` template (netresearch/.github): explicit per-call-site permissions on every reusable, drift-enforced. Security/quality jobs (checks.yml) are byte-governed; the test matrix (ci.yml) and release.yml are per-repo (intentional-drift, preserved from this repo).